### PR TITLE
Give warning for missing pool and continue

### DIFF
--- a/Puli/src/octopus/dispatcher/db/pulidb.py
+++ b/Puli/src/octopus/dispatcher/db/pulidb.py
@@ -798,11 +798,14 @@ class PuliDB(object):
         for num, dbPoolShare in enumerate(poolShares):
             id, poolId, nodeId, maxRN, archived = dbPoolShare
             #FIXME temp
-            if nodeId in nodesById.keys():
-                realPoolShare = PoolShare(id,
-                                      poolsById[poolId],
-                                      nodesById[nodeId],
-                                      maxRN)
+            if not poolId in poolsById.keys():
+                print "%s !!! Warning: PoolShare %d references nonexisting pool ID (%d)" % (time.strftime('[%H:%M:%S]', time.gmtime(time.time() - begintime)),id,poolId)
+            else:
+                if nodeId in nodesById.keys():
+                    realPoolShare = PoolShare(id,
+                                          poolsById[poolId],
+                                          nodesById[nodeId],
+                                          maxRN)
             tree.poolShares[realPoolShare.id] = realPoolShare
 
         print "%s -- poolshares complete --" % (time.strftime('[%H:%M:%S]', time.gmtime(time.time() - begintime)))


### PR DESCRIPTION
For some reason I've got wrong poolId in my DB and dispatcherd refused to start. This commit ignores the missing pool id and allows to continue.
