### PR TITLE
Remove 'pulicontrib' from default watcherPackages

### DIFF
--- a/src/puliclient/__init__.py
+++ b/src/puliclient/__init__.py
@@ -271,7 +271,7 @@ class Task(object):
         self.timer = timer
         self.maxAttempt = maxAttempt
         self.runnerPackages = None
-        self.watcherPackages = 'pulicontrib'
+        self.watcherPackages = ''
 
         if runnerPackages:
             self.runnerPackages = runnerPackages


### PR DESCRIPTION
WatcherPackages is empty by default.

If not defined in task argument, parse 'REZ_USED_RESOLVE' for
pulicontrib package.

Note : watcherPackages will be empty if pulicontrib is not defined is
REZ environement or in task attibutes.